### PR TITLE
Fix for some Exceptions and Support for AssetReferenceT<>

### DIFF
--- a/Editor/Assigners/AssetReferenceTAssigner.cs
+++ b/Editor/Assigners/AssetReferenceTAssigner.cs
@@ -1,0 +1,80 @@
+#if UNITY_ADDRESSABLES
+using System;
+using AutoAssigner.Providers;
+using UnityEditor;
+using UnityEngine.AddressableAssets;
+
+namespace AutoAssigner.Assigners
+{
+    public class AssetReferenceTAssigner : ISubAssigner
+    {
+        public bool TryAssign(SerializedProperty property)
+        {
+            if (property.propertyType != SerializedPropertyType.Generic)
+                return false;
+
+            if (property.isArray || property.IsArrayElement())
+                return false;
+
+            property.GetFieldInfoAndStaticType(out Type fieldType);
+            
+            if (!IsAssignableToGenericType(fieldType, typeof(AssetReferenceT<>)))
+                return false;
+
+            var obj = property.GetObject();
+            if (obj is not AssetReference assetRef)
+                return false;
+
+            if (assetRef.editorAsset != null)
+                return true;
+
+            var genericType = GetGenericType(fieldType);
+            if (genericType == null)
+                return false;
+            
+            var targetName = $"{genericType.Name} {property.name}";
+            var targetObj = ObjectProvider.GetOne(genericType, targetName);
+            if (targetObj == null)
+                targetObj = PrefabProvider.GetOne(genericType, targetName);
+
+            assetRef.SetEditorAsset(targetObj);
+            assetRef.SetEditorSubObject(targetObj);
+            
+            //We must Update SerializedObject to read new values
+            property.serializedObject.Update();
+            
+            return true;
+        }
+
+        //It's tricky to detect both AssetReferenceT<Sprite> and AssetReferenceSprite
+        private bool IsAssignableToGenericType(Type givenType, Type genericType)
+        {
+            if (givenType == null || genericType == null)
+                return false;
+
+            if (givenType.IsGenericType && 
+                genericType.IsAssignableFrom(givenType.GetGenericTypeDefinition()))
+                return true;
+
+            var baseType = givenType.BaseType;
+            return IsAssignableToGenericType(baseType, genericType);
+        }
+
+        //Return Sprite for both AssetReferenceT<Sprite> and AssetReferenceSprite
+        private Type GetGenericType(Type givenType)
+        {
+            if (givenType == null)
+                return null;
+
+            if (givenType.IsGenericType)
+            {
+                var genericArguments = givenType.GetGenericArguments();
+                return genericArguments.Length == 0 ? null : genericArguments[0];
+            }
+            
+            var baseType = givenType.BaseType;
+            return GetGenericType(baseType);
+        }
+    }
+}
+#endif

--- a/Editor/Assigners/AssetReferenceTAssigner.cs.meta
+++ b/Editor/Assigners/AssetReferenceTAssigner.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1abb1bd52cec4813b7e7517441546e73
+timeCreated: 1718917066

--- a/Editor/Assigners/ComponentArrayAssigner.cs
+++ b/Editor/Assigners/ComponentArrayAssigner.cs
@@ -27,7 +27,8 @@ namespace AutoAssigner.Assigners
 
             List<Component> all;
 
-            if (!property.HasPrefabInTheName())
+            var isComponent = property.serializedObject.targetObject is Component;
+            if (!property.HasPrefabInTheName() && isComponent)
             {
                 var root = (Component)property.serializedObject.targetObject;
                 all = root.GetComponentsInChildren(element, true).ToList();

--- a/Editor/Assigners/ComponentAssigner.cs
+++ b/Editor/Assigners/ComponentAssigner.cs
@@ -33,13 +33,12 @@ namespace AutoAssigner.Assigners
                 if (children.Length != 0)
                 {
                     (property.objectReferenceValue, _) = NameProcessor.GetMatching(children, property.GetTargetName());
+                    if (property.objectReferenceValue != null)
+                        return true;
                 }
             }
-            else
-            {
-                property.objectReferenceValue = PrefabProvider.GetOne(fieldType, property.GetTargetName());
-            }
 
+            property.objectReferenceValue = PrefabProvider.GetOne(fieldType, property.GetTargetName());
             return true;
         }
     }

--- a/Editor/Assigners/ComponentAssigner.cs
+++ b/Editor/Assigners/ComponentAssigner.cs
@@ -24,7 +24,8 @@ namespace AutoAssigner.Assigners
             if (property.objectReferenceValue != null)
                 return true;
 
-            if (!property.HasPrefabInTheName())
+            var isComponent = property.serializedObject.targetObject is Component;
+            if (!property.HasPrefabInTheName() && isComponent)
             {
                 var root = (Component)property.serializedObject.targetObject;
                 Component[] children = root.GetComponentsInChildren(fieldType, true);

--- a/Editor/AutoAssigner.Editor.asmdef
+++ b/Editor/AutoAssigner.Editor.asmdef
@@ -10,8 +10,10 @@
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": true,
-    "precompiledReferences": [],
+    "overrideReferences": false,
+    "precompiledReferences": [
+        ""
+    ],
     "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [

--- a/Editor/AutoAssigner.Editor.asmdef
+++ b/Editor/AutoAssigner.Editor.asmdef
@@ -2,7 +2,8 @@
     "name": "AutoAssigner.Editor",
     "rootNamespace": "AutoAssigner",
     "references": [
-        "AutoAssigner"
+        "AutoAssigner",
+        "Unity.Addressables"
     ],
     "includePlatforms": [
         "Editor"
@@ -13,6 +14,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.addressables",
+            "expression": "",
+            "define": "UNITY_ADDRESSABLES"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Editor/Providers/PrefabProvider.cs
+++ b/Editor/Providers/PrefabProvider.cs
@@ -48,7 +48,8 @@ namespace AutoAssigner.Providers
 
             (string bestPath, _) = NameProcessor.GetMatching(paths, targetName);
 
-            return AssetDatabase.LoadAssetAtPath<GameObject>(bestPath).GetComponent(t);
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(bestPath);
+            return prefab != null ? prefab.GetComponent(t) : null;
         }
 
         public static GameObject GetOne(string targetName)

--- a/Editor/SerializedPropertyExtensions.cs
+++ b/Editor/SerializedPropertyExtensions.cs
@@ -76,5 +76,14 @@ namespace AutoAssigner
                    && property.propertyPath.Contains("[")
                    && property.propertyPath.Contains("]");
         }
+
+        public static object GetObject(this SerializedProperty property)
+        {
+            object obj = property.serializedObject.targetObject;
+            string path = property.propertyPath;
+            BindingFlags bindings = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
+            FieldInfo field = obj.GetType().GetField(path, bindings);
+            return field != null ? field.GetValue(obj) : default(object);
+        }
     }
 }


### PR DESCRIPTION
Hi,
I ran into these problems and I fix them on my fork:
1) InvalidCastException: if call Auto Assign on ScriptableObject to find Prefabs that their property name not contains 'prefab'
https://github.com/pnarimani/AutoAssigner/issues/1#issue-2362194784

2) NullReferenceException on prefab provider

and also I implemented support for AssetReferenceT<> 